### PR TITLE
compare functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var isArray = Array.isArray;
 var keyList = Object.keys;
 var hasProp = Object.prototype.hasOwnProperty;
+var fnNameRegex = /^function\s?\S*\(/;
 
 function equal(a, b) {
   if (a === b) return true;
@@ -33,6 +34,16 @@ function equal(a, b) {
   if (regexpA != regexpB) return false;
   if (regexpA && regexpB) return a.toString() == b.toString();
 
+  var fnA = a instanceof Function
+    , fnB = b instanceof Function;
+  if (fnA != fnB) return false;
+  if (fnA && fnB) {
+    return (
+      a.toString().replace(fnNameRegex, '') ==
+      b.toString().replace(fnNameRegex, '')
+    );
+  }
+
   if (a instanceof Object && b instanceof Object) {
     var keys = keyList(a);
     length = keys.length;
@@ -59,6 +70,7 @@ function equal(a, b) {
 
     return true;
   }
+
 
   return false;
 }

--- a/test/node/tests.js
+++ b/test/node/tests.js
@@ -1,5 +1,17 @@
 'use strict';
 
+function add(a, b) {
+  return a + b;
+}
+
+function add2(a, b) {
+  return a + b;
+}
+
+function minus(a, b) {
+  return a - b;
+}
+
 const generic = [
   {
     description: 'scalars',
@@ -315,6 +327,35 @@ const generic = [
         },
         equal: true
       }
+    ]
+  },
+  {
+    description: 'functions',
+    tests: [
+      {
+        description: 'equal nested lambda functions',
+        value1: function() {},
+        value2: function() {},
+        equal: true
+      },
+      {
+        description: 'equal nested lambda functions',
+        value1: {a: function() {}},
+        value2: {a: function() {}},
+        equal: true
+      },
+      {
+        description: 'equal differently named functions',
+        value1: add,
+        value2: add2,
+        equal: true
+      },
+      {
+        description: 'not equal named functions',
+        value1: add,
+        value2: minus,
+        equal: false
+      },
     ]
   }
 ];


### PR DESCRIPTION
- common use case is to provide function as prop
- use case in redux is to provide action creator function to components

- There is a option replace using function.name without regex but it might replace something else in the code as well. 
```js
if (fnA && fnB) {
    return (
      a.toString().replace('function ' + a.name, '') ===
      b.toString().replace('function ' + b.name, '')
    );
  }
```