### PR TITLE
fix react check to work in prod

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function equal(a, b) {
     // Custom handling for React
     for (i = length; i-- !== 0;) {
       key = keys[i];
-      if (key === '_owner' && a.$$typeof && a._store) {
+      if (key === '_owner' && a.$$typeof) {
         // React-specific: avoid traversing React elements' _owner.
         //  _owner contains circular references
         // and is not needed when comparing the actual elements (and not their owners)


### PR DESCRIPTION
Addresses https://github.com/FormidableLabs/react-fast-compare/issues/25 by removing the _store check.

More specificity can be added by depending upon https://github.com/facebook/react/blob/master/packages/shared/ReactSymbols.js and comparing $$typeof as mentioned in https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js#L92.