### PR TITLE
Optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function equal(a, b) {
 
     // start react-fast-compare
     // custom handling for DOM elements
-    if (hasElementType && a instanceof Element && b instanceof Element)
+    if (hasElementType && a instanceof Element)
       return a === b;
 
     // custom handling for React

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function equal(a, b) {
     // start react-fast-compare
     // custom handling for DOM elements
     if (hasElementType && a instanceof Element)
-      return a === b;
+      return false;
 
     // custom handling for React
     for (i = length; i-- !== 0;) {


### PR DESCRIPTION
Removes two unnecessary expressions:

- `b instanceof Element` is not needed because if `a` is instanceof `Elemement` and tripple equals is used `a === b`, then `b` must be instance of `Element`, too.
- `a === b` is not needed, as the very first line of this function already checks for that: `if (a === b) return true;`.