### PR TITLE
add maintenance status note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Travis Status][trav_img]][trav_site]
 [![AppVeyor Status][appveyor_img]][appveyor_site]
 [![npm version][npm_img]][npm_site]
+[![Maintenance Status][maintenance-image]](#maintenance-status)
+
 
 The fastest deep equal comparison for React. Really fast general-purpose deep comparison.
 Great for`shouldComponentUpdate`. This is a fork of the brilliant
@@ -15,10 +17,6 @@ extra handling for React.
 ![benchmark chart](assets/benchmarking.png "benchmarking chart")
 
 (Check out the [benchmarking details](#benchmarking-this-library).)
-
-### Maintenance Status: Active
-
-Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
 
 ## Install
 
@@ -133,6 +131,10 @@ react-fast-compare@2 tracks fast-deep-equal@2.0.1
 
 Please see our [contributions guide](./CONTRIBUTING.md).
 
+## Maintenance Status
+
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
 [trav_img]: https://api.travis-ci.org/FormidableLabs/react-fast-compare.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/react-fast-compare
 [cov_img]: https://img.shields.io/coveralls/FormidableLabs/react-fast-compare.svg
@@ -145,3 +147,4 @@ Please see our [contributions guide](./CONTRIBUTING.md).
 [size_minzip]: https://img.shields.io/bundlephobia/minzip/react-fast-compare.svg
 [size_site]: https://bundlephobia.com/result?p=react-fast-compare
 [downloads_img]: https://img.shields.io/npm/dt/react-fast-compare.svg
+[maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ extra handling for React.
 
 (Check out the [benchmarking details](#benchmarking-this-library).)
 
+### Maintenance Status: Active
+
+Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
 ## Install
 
 ```sh


### PR DESCRIPTION
@chrisbolin we're adding maintenance status to all our OSS. I think `react-fast-compare` should probably be listed as "Active". I also considered "Stable". If you think that's more appropriate, please replace my note with:

```
## Maintenance Status

**Stable:** Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
```

and change the badge image to:

```
[maintenance-image]: https://img.shields.io/badge/maintenance-stable-blue.svg
```

Let me know if you have any questions