### PR TITLE
Improve performance by avoiding extra work

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,60 +10,51 @@ function equal(a, b) {
   if (a === b) return true;
 
   if (a && b && typeof a == 'object' && typeof b == 'object') {
-    var arrA = isArray(a)
-      , arrB = isArray(b)
-      , i
-      , length
-      , key;
+    var i;
 
-    if (arrA && arrB) {
-      length = a.length;
-      if (length != b.length) return false;
-      for (i = length; i-- !== 0;)
-        if (!equal(a[i], b[i])) return false;
+    if (isArray(a)) {
+      if (!isArray(b)) return false;
+      if (a.length !== b.length) return false;
+      i = a.length;
+      while (i--) if (!equal2(a[i], b[i])) return false;
       return true;
     }
 
-    if (arrA != arrB) return false;
+    if (a instanceof Date) {
+      if (!(b instanceof Date)) return false;
+      return a.getTime() == b.getTime();
+    }
 
-    var dateA = a instanceof Date
-      , dateB = b instanceof Date;
-    if (dateA != dateB) return false;
-    if (dateA && dateB) return a.getTime() == b.getTime();
-
-    var regexpA = a instanceof RegExp
-      , regexpB = b instanceof RegExp;
-    if (regexpA != regexpB) return false;
-    if (regexpA && regexpB) return a.toString() == b.toString();
+    if (a instanceof RegExp) {
+      if (!(b instanceof RegExp)) return false;
+      return a.toString() == b.toString();
+    }
 
     var keys = keyList(a);
-    length = keys.length;
 
-    if (length !== keyList(b).length)
-      return false;
+    if (keys.length !== keyList(b).length) return false;
 
-    for (i = length; i-- !== 0;)
-      if (!hasProp.call(b, keys[i])) return false;
+    i = keys.length;
+
+    while (i--) if (!hasProp.call(b, keys[i])) return false;
     // end fast-deep-equal
 
     // start react-fast-compare
     // custom handling for DOM elements
-    if (hasElementType && a instanceof Element)
-      return false;
+    if (hasElementType && a instanceof Element) return false;
 
     // custom handling for React
-    for (i = length; i-- !== 0;) {
-      key = keys[i];
-      if (key === '_owner' && a.$$typeof) {
-        // React-specific: avoid traversing React elements' _owner.
-        //  _owner contains circular references
-        // and is not needed when comparing the actual elements (and not their owners)
-        // .$$typeof and ._store on just reasonable markers of a react element
-        continue;
-      } else {
-        // all other properties should be traversed as usual
-        if (!equal(a[key], b[key])) return false;
-      }
+    i = keys.length;
+
+    while (i--) {
+      // React-specific: avoid traversing React elements' _owner.
+      //  _owner contains circular references
+      // and is not needed when comparing the actual elements (and not their owners)
+      // .$$typeof and ._store on just reasonable markers of a react element
+      if (keys[i] === '_owner' && a.$$typeof) continue;
+
+      // all other properties should be traversed as usual
+      if (!equal2(a[keys[i]], b[keys[i]])) return false;
     }
     // end react-fast-compare
 

--- a/index.js
+++ b/index.js
@@ -25,11 +25,15 @@ function equal(a, b) {
     if (a instanceof Date) {
       if (!(b instanceof Date)) return false;
       return a.getTime() == b.getTime();
+    } else if (b instanceof Date) {
+      return false;
     }
 
     if (a instanceof RegExp) {
       if (!(b instanceof RegExp)) return false;
       return a.toString() == b.toString();
+    } else if (b instanceof RegExp) {
+      return false;
     }
 
     var keys = keyList(a);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function equal(a, b) {
       if (!isArray(b)) return false;
       if (a.length !== b.length) return false;
       i = a.length;
-      while (i--) if (!equal2(a[i], b[i])) return false;
+      while (i--) if (!equal(a[i], b[i])) return false;
       return true;
     }
 
@@ -54,7 +54,7 @@ function equal(a, b) {
       if (keys[i] === '_owner' && a.$$typeof) continue;
 
       // all other properties should be traversed as usual
-      if (!equal2(a[keys[i]], b[keys[i]])) return false;
+      if (!equal(a[keys[i]], b[keys[i]])) return false;
     }
     // end react-fast-compare
 

--- a/index.js
+++ b/index.js
@@ -10,37 +10,32 @@ function equal(a, b) {
   if (a === b) return true;
 
   if (a && b && typeof a == 'object' && typeof b == 'object') {
-    var i;
-
     if (isArray(a)) {
-      if (!isArray(b)) return false;
-      if (a.length !== b.length) return false;
-      i = a.length;
+      if (!isArray(b) || a.length !== b.length) return false;
+      var i = a.length;
       while (i--) if (!equal(a[i], b[i])) return false;
       return true;
-    } else if (isArray(b)) {
-      return false;
     }
+
+    if (isArray(b)) return false;
 
     if (a instanceof Date) {
-      if (!(b instanceof Date)) return false;
-      return a.getTime() == b.getTime();
-    } else if (b instanceof Date) {
-      return false;
+      return b instanceof Date && a.getTime() == b.getTime();
     }
 
+    if (b instanceof Date) return false;
+
     if (a instanceof RegExp) {
-      if (!(b instanceof RegExp)) return false;
-      return a.toString() == b.toString();
-    } else if (b instanceof RegExp) {
-      return false;
+      return b instanceof RegExp && a.toString() == b.toString();
     }
+
+    if (b instanceof RegExp) return false;
 
     var keys = keyList(a);
 
     if (keys.length !== keyList(b).length) return false;
 
-    i = keys.length;
+    var i = keys.length;
 
     while (i--) if (!hasProp.call(b, keys[i])) return false;
     // end fast-deep-equal

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function equal(a, b) {
       i = a.length;
       while (i--) if (!equal(a[i], b[i])) return false;
       return true;
+    } else if (isArray(b)) {
+      return false;
     }
 
     if (a instanceof Date) {

--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ function equal(a, b) {
   if (a === b) return true;
 
   if (a && b && typeof a == 'object' && typeof b == 'object') {
+    var i;
     if (isArray(a)) {
       if (!isArray(b) || a.length !== b.length) return false;
-      let i = a.length;
+      i = a.length;
       while (i--) if (!equal(a[i], b[i])) return false;
       return true;
     }
@@ -29,7 +30,7 @@ function equal(a, b) {
 
     if (keys.length !== keyList(b).length) return false;
 
-    let i = keys.length;
+    i = keys.length;
 
     while (i--) if (!hasProp.call(b, keys[i])) return false;
     // end fast-deep-equal

--- a/index.js
+++ b/index.js
@@ -12,30 +12,24 @@ function equal(a, b) {
   if (a && b && typeof a == 'object' && typeof b == 'object') {
     if (isArray(a)) {
       if (!isArray(b) || a.length !== b.length) return false;
-      var i = a.length;
+      let i = a.length;
       while (i--) if (!equal(a[i], b[i])) return false;
       return true;
     }
 
     if (isArray(b)) return false;
 
-    if (a instanceof Date) {
-      return b instanceof Date && a.getTime() == b.getTime();
-    }
-
+    if (a instanceof Date) return b instanceof Date && a.getTime() == b.getTime();
     if (b instanceof Date) return false;
 
-    if (a instanceof RegExp) {
-      return b instanceof RegExp && a.toString() == b.toString();
-    }
-
+    if (a instanceof RegExp) return b instanceof RegExp && a.toString() == b.toString();
     if (b instanceof RegExp) return false;
 
     var keys = keyList(a);
 
     if (keys.length !== keyList(b).length) return false;
 
-    var i = keys.length;
+    let i = keys.length;
 
     while (i--) if (!hasProp.call(b, keys[i])) return false;
     // end fast-deep-equal


### PR DESCRIPTION
This version avoids work in a few ways.

1. Not declaring extra variables
2. Using while loops without an extra comparison

There may be an extra gain on line 12, if the data isn't expected to have a lot of `null` values,
you could potentially do the object checks first, then the truthy `a && b` check.