### PR TITLE
rename exportedEqual to isEqual

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare module 'react-fast-compare' {
-  const exportedEqual: (a: any, b: any) => boolean
-  export default exportedEqual
+  const isEqual: (a: any, b: any) => boolean
+  export default isEqual
 }

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function equal(a, b) {
 }
 // end fast-deep-equal
 
-module.exports = function exportedEqual(a, b) {
+module.exports = function isEqual(a, b) {
   try {
     return equal(a, b);
   } catch (error) {


### PR DESCRIPTION
In JS this function name is irrelevant, but in _TypeScript_ this name is visible in many editors (e.g. PhpStorm, see #58).