### PR TITLE
Fix incorrect Typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-declare module 'react-fast-compare' {
-  const isEqual: (a: any, b: any) => boolean
-  export default isEqual
-}
+function isEqual(a: any, b: any): boolean;
+declare namespace isEqual {}
+export = isEqual;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-function isEqual(a: any, b: any): boolean;
+declare function isEqual(a: any, b: any): boolean;
 declare namespace isEqual {}
 export = isEqual;


### PR DESCRIPTION
While trying to use this from TS, I noticed that I got the following error: `a.default is not a function`, which hinted at some import problem with this package.

After looking at the source code (specifically [this line](https://github.com/FormidableLabs/react-fast-compare/blob/master/index.js#L114)), it is evident that this package is what TS calls a "module library" - http://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html#identifying-a-module-library-from-code). Looking at other similar packages (namely `request`), you can see that their type definitions are not using `export default`.

As such, it seems that the types in this package should be changed:

```ts
declare function isEqual(a: any, b: any): boolean;
declare namespace isEqual {}
export = isEqual;
```