### PR TITLE
add __v and __o keys to the custom handler to support Preact

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,13 +88,17 @@ function equal(a, b) {
     // custom handling for DOM elements
     if (hasElementType && a instanceof Element) return false;
 
-    // custom handling for React
+    // custom handling for React/Preact
     for (i = length; i-- !== 0;) {
-      if (keys[i] === '_owner' && a.$$typeof) {
-        // React-specific: avoid traversing React elements' _owner.
-        //  _owner contains circular references
-        // and is not needed when comparing the actual elements (and not their owners)
-        // .$$typeof and ._store on just reasonable markers of a react element
+      if ((keys[i] === '_owner' || keys[i] === '__v' || keys[i] === '__o') && a.$$typeof) {
+        // React-specific: avoid traversing React elements' _owner
+        // Preact-specific: avoid traversing Preact elements' __v and __o
+        //    __v = $_original / $_vnode
+        //    __o = $_owner
+        // These properties contain circular references and are not needed when
+        // comparing the actual elements (and not their owners)
+        // .$$typeof and ._store on just reasonable markers of elements
+
         continue;
       }
 


### PR DESCRIPTION
Hi there,

I'm using preact and I noticed this console warning in my browser:
`react-fast-compare cannot handle circular refs`

After a bit of investigation I found out that one of my dependencies is using `react-fast-compare` which would work fine with preact as well after a minor modification.
Instead of forking the project (e.g. `preact-fast-compare`) I thought it would be better to contribute to the project and make it work with both frameworks.