### PR TITLE
Fix broken chart in the hosted docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a fork of the brilliant
 [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal) with some
 extra handling for React.
 
-![benchmark chart](assets/benchmarking.png "benchmarking chart")
+![benchmark chart](https://raw.githubusercontent.com/FormidableLabs/react-fast-compare/master/assets/benchmarking.png "benchmarking chart")
 
 (Check out the [benchmarking details](#benchmarking-this-library).)
 


### PR DESCRIPTION
Because we were using a relative path to import the benchmarking chart in our Readme, the formidable.com mirror of our docs has nothing to source for that img. This PR fixes that by relying on the latest chart in master, for now.

Closes #73