### PR TITLE
Only iterate over `Map`s once

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,6 @@ Please see our [contributions guide](./CONTRIBUTING.md).
 [npm_site]: http://badge.fury.io/js/react-fast-compare
 [appveyor_img]: https://ci.appveyor.com/api/projects/status/github/formidablelabs/react-fast-compare?branch=master&svg=true
 [appveyor_site]: https://ci.appveyor.com/project/FormidableLabs/react-fast-compare
-[bundle_img]: https://img.shields.io/badge/minzipped%20size-639%20B-flatgreen.svg
+[bundle_img]: https://img.shields.io/badge/minzipped%20size-643%20B-flatgreen.svg
 [downloads_img]: https://img.shields.io/npm/dm/react-fast-compare.svg
 [maintenance_img]: https://img.shields.io/badge/maintenance-active-flatgreen.svg

--- a/index.js
+++ b/index.js
@@ -47,11 +47,10 @@ function equal(a, b) {
     if (hasMap && (a instanceof Map) && (b instanceof Map)) {
       if (a.size !== b.size) return false;
       it = a.entries();
-      while (!(i = it.next()).done)
+      while (!(i = it.next()).done) {
         if (!b.has(i.value[0])) return false;
-      it = a.entries();
-      while (!(i = it.next()).done)
         if (!equal(i.value[1], b.get(i.value[0]))) return false;
+      }
       return true;
     }
 


### PR DESCRIPTION
## Description

Before this commit, the logic was (roughly):

1. For each key of `a`, make sure the key is present in `b`.
2. For each key of `a`, make sure the corresponding value in `b` is equal.

Now, there's only one loop. The logic is now:

1. For each key of `a`...
   1. Make sure the key is present in `b`.
   2. Make sure the corresponding value in `b` is equal.

This change was also made upstream in `fast-deep-equal`. See <https://github.com/epoberezkin/fast-deep-equal/pull/130>.

## Checklist:

- [x] All tests are passing
- [x] Type definitions, if updated, pass both `test-ts-defs` and `test-ts-usage`
- [x] Benchmark performance has not significantly decreased
- [x] Bundle size has not been significantly impacted
- [x] The bundle size badge has been updated to reflect the new size
