### PR TITLE
Bugfix: support Object.create(null)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+**Bugfixes:**
+
+- Fix Object with null prototype errors [#64](https://github.com/FormidableLabs/react-fast-compare/issues/64).
+
 ## 3.2.0 (2020-05-28)
 
 - [#80](https://github.com/FormidableLabs/react-fast-compare/pull/80). Update types to use generic `any`s.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install react-fast-compare
 - handles React-specific circular references, like elements
 - checks equality Date and RegExp objects
 - should as fast as [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal) via a single unified library, and with added guardrails for circular references.
-- small: under 650 bytes minified+gzipped
+- small: under 660 bytes minified+gzipped
 
 ## Usage
 
@@ -160,6 +160,6 @@ Please see our [contributions guide](./CONTRIBUTING.md).
 [npm_site]: http://badge.fury.io/js/react-fast-compare
 [appveyor_img]: https://ci.appveyor.com/api/projects/status/github/formidablelabs/react-fast-compare?branch=master&svg=true
 [appveyor_site]: https://ci.appveyor.com/project/FormidableLabs/react-fast-compare
-[bundle_img]: https://img.shields.io/badge/minzipped%20size-639%20B-flatgreen.svg
+[bundle_img]: https://img.shields.io/badge/minzipped%20size-656%20B-flatgreen.svg
 [downloads_img]: https://img.shields.io/npm/dm/react-fast-compare.svg
 [maintenance_img]: https://img.shields.io/badge/maintenance-active-flatgreen.svg

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var hasArrayBuffer = typeof ArrayBuffer === 'function' && !!ArrayBuffer.isView;
 // Note: We **don't** need `envHasBigInt64Array` in fde es6/index.js
 
 function equal(a, b) {
-  // START: fast-deep-equal es6/index.js 3.1.1
+  // START: fast-deep-equal es6/index.js 3.1.3
   if (a === b) return true;
 
   if (a && b && typeof a == 'object' && typeof b == 'object') {
@@ -73,8 +73,13 @@ function equal(a, b) {
     }
 
     if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
-    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+    // START: Modifications:
+    // Apply guards for `Object.create(null)` handling. See:
+    // - https://github.com/FormidableLabs/react-fast-compare/issues/64
+    // - https://github.com/epoberezkin/fast-deep-equal/issues/49
+    if (a.valueOf !== Object.prototype.valueOf && typeof a.valueOf === 'function' && typeof b.valueOf === 'function') return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString && typeof a.toString === 'function' && typeof b.toString === 'function') return a.toString() === b.toString();
+    // END: Modifications
 
     keys = Object.keys(a);
     length = keys.length;

--- a/test/node/tests.js
+++ b/test/node/tests.js
@@ -64,9 +64,49 @@ const react = [
   }
 ];
 
+// Additional customized behavior.
+const custom = [
+  {
+    description: 'Custom tests',
+    tests: [
+      {
+        description: 'Object.create(null) equal',
+        value1: Object.create(null),
+        value2: Object.create(null),
+        equal: true
+      },
+      {
+        description: 'Object.create(null) unequal to empty object',
+        value1: Object.create(null),
+        value2: {},
+        equal: false
+      },
+      {
+        description: 'Object.create(null) unequal to non-empty object',
+        value1: Object.create(null),
+        value2: { a: 1 },
+        equal: false
+      },
+      {
+        description: 'Object.create(null) equal to vanilla deep objects',
+        value1: Object.assign(Object.create(null), { a: 1, b: { c: true } }),
+        value2: { a: 1, b: { c: true } },
+        equal: false
+      },
+      {
+        description: 'Object.create(null) equal for deep objects',
+        value1: Object.assign(Object.create(null), { a: 1, b: { c: true } }),
+        value2: Object.assign(Object.create(null), { b: { c: true }, a: 1 }),
+        equal: true
+      }
+    ]
+  }
+];
+
 module.exports = {
   generic,
   es6,
   react,
-  all: [...generic, ...es6, ...react],
+  custom,
+  all: [].concat(generic, es6, react, custom),
 };


### PR DESCRIPTION
- Allow use of `Object.create(null)` to work without error. Fixes #64 
- Add customized tests.
