### PR TITLE
Update deprecated actions/checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global core.autocrlf false
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
<!--

For more information on any of the below, please see our Contributing guidelines:
https://github.com/FormidableLabs/react-fast-compare/blob/master/CONTRIBUTING.md#before-submitting-a-pr

-->

## Description

Github actions/checkout@v2 is deprecated due to Node 12. This PR updates both workflows to use v3 instead. They should be functionally equivalent, as the only change is [the upgrade to Node 16](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300).

(This does not affect our test matrix in the CI workflow, the Node version mentioned above is upgraded only for the checkout step.)

This PR removes this warning from all workflow runs:
<img width="857" alt="image" src="https://github.com/FormidableLabs/react-fast-compare/assets/318504/27d78ef2-4870-48eb-b8fc-35563f7a8807">

## Checklist:

- [x] All tests are passing
- [x] Type definitions, if updated, pass both `test-ts-defs` and `test-ts-usage`
- [x] Benchmark performance has not significantly decreased
- [x] Bundle size has not been significantly impacted
- [x] The bundle size badge has been updated to reflect the new size
