### PR TITLE
use node 18 and clear pipeline warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
+          cache: "yarn"
           node-version: ${{ matrix.node_version }}
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           git config --global core.autocrlf false
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node_version:
-          - 14
-          - 16
           - 18
     name: Node ${{ matrix.node_version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          cache: "yarn"
           node-version: 18
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
       packages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
<!--

For more information on any of the below, please see our Contributing guidelines:
https://github.com/FormidableLabs/react-fast-compare/blob/master/CONTRIBUTING.md#before-submitting-a-pr

-->

## Description

As part of an internal Formidable Open Source audit, we're going through and updating some GH actions to no longer use unsupported versions of node. Also, removing them from our testing pipelines.

I also noticed we weren't utilizing a cache for yarn, so I added that into `setup-node` action to speed things up slightly.


## Checklist:

- [x] All tests are passing
- [x] Type definitions, if updated, pass both `test-ts-defs` and `test-ts-usage`
- [x] Benchmark performance has not significantly decreased
- [x] Bundle size has not been significantly impacted
- [x] The bundle size badge has been updated to reflect the new size
